### PR TITLE
Add initial tests for Market

### DIFF
--- a/test/TestMarket.js
+++ b/test/TestMarket.js
@@ -1,0 +1,22 @@
+const Property = artifacts.require("Market.sol");
+const Market = artifacts.require("Market.sol");
+
+contract('Market', function (accounts) {
+    let property;
+    let market;
+
+    beforeEach(async () => {
+        property = await Property.new();
+        market = await Market.new(property.address, "3600", "114155", "10000000000000000", "0x0");
+    });
+
+    it('should register a seller', async () => {
+        await market.register(accounts[0], "testURI");
+
+        const tokens = await property.tokensByCreator(accounts[0]);
+
+        assert.equal(tokens.length, 1);
+        assert.equal(await property.tokenURI(tokens[0]), "testURI");
+        assert.equal((await market.priceOf(tokens[0])).toString(), "0");
+    });
+});

--- a/test/TestMarket.js
+++ b/test/TestMarket.js
@@ -1,4 +1,4 @@
-const Property = artifacts.require("Market.sol");
+const Property = artifacts.require("Property.sol");
 const Market = artifacts.require("Market.sol");
 
 contract('Market', function (accounts) {
@@ -8,10 +8,11 @@ contract('Market', function (accounts) {
     beforeEach(async () => {
         property = await Property.new();
         market = await Market.new(property.address, "3600", "114155", "10000000000000000", "0x0");
+        property.transferOwnership(market.address);
     });
 
     it('should register a seller', async () => {
-        await market.register(accounts[0], "testURI");
+        await market.register("testURI");
 
         const tokens = await property.tokensByCreator(accounts[0]);
 

--- a/test/TestMarket.js
+++ b/test/TestMarket.js
@@ -11,6 +11,13 @@ contract('Market', function (accounts) {
         property.transferOwnership(market.address);
     });
 
+    it('basic market properties be correct', async () => {
+        assert.equal((await market.interval()).toString(), "3600");
+        assert.equal((await market.taxRatePerInterval()).toString(), "114155");
+        assert.equal((await market.taxPrecision()).toString(), "1000000");
+        assert.equal((await market.epsilon()).toString(), "10000000000000000");
+    });
+
     it('should register a seller', async () => {
         await market.register("testURI");
 


### PR DESCRIPTION
Part of #20.

This is not working for some reason:
```
  1) Contract: Market
       "before each" hook for "should register a seller":
     Error: Market contract constructor expected 5 arguments, received 0
```

Yet clearly it has 5 args.